### PR TITLE
use the name of the lib if available for soname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.idea

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,12 @@ use toml;
 #[derive(Deserialize)]
 pub struct Manifest {
     pub package: Package,
+    pub lib: Option<OptPackage>,
+}
+
+#[derive(Deserialize)]
+pub struct OptPackage {
+    pub name: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -25,7 +31,10 @@ fn get_name() -> String {
 
     let manifest: Manifest = toml::from_str(&s).unwrap();
 
-    manifest.package.name
+    manifest
+        .lib
+        .and_then(|it| it.name)
+        .unwrap_or(manifest.package.name)
 }
 
 pub fn metabuild() {


### PR DESCRIPTION
Hi there !

Here is a small pull request that fixes a small bug when the name of the lib is overridden in the `Cargo.toml`.

With the current version, if I have a `Cargo.toml` like this one 

```
[package]
name = "foo-lib"
version = "0.1.0"
...

[lib]
name = "foo"
```
then the produced so is named `libfoo.so`, but the `SONAME` is set to `libfoo-lib.so.0`.

This pull request fixes the `SONAME` to be the expected `libfoo.so.0`

(I also included a new line in the `.gitignore` to ignore files created by IntelliJ)



