### PR TITLE
Add DT_SONAME on musl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub fn shared_object_link_args(
             lines.push(format!("-Wl,-soname,lib{}.so", name));
         }
 
-        ("linux", _) | ("freebsd", _) | ("dragonfly", _) | ("netbsd", _) if env != "musl" => {
+        ("linux", _) | ("freebsd", _) | ("dragonfly", _) | ("netbsd", _) => {
             lines.push(format!("-Wl,-soname,lib{}.so.{}", name, major));
         }
 


### PR DESCRIPTION
It should set DT_SONAME for musl targets as well.
Related: https://github.com/lu-zero/cargo-c/commit/38942b59567f0ef239d615bd9cecad2f9ca8139b